### PR TITLE
Test: Complete and enhance test coverage for Utilities and ConfigureP…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,8 +26,8 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>3.0</version>
 				<configuration>
-					<source>1.6</source>
-					<target>1.6</target>
+					<source>1.8</source>
+					<target>1.8</target>
 					<encoding>UTF-8</encoding>
 				</configuration>
 			</plugin>

--- a/src/test/java/com/taobao/profile/test/ConfigurePropertiesTest.java
+++ b/src/test/java/com/taobao/profile/test/ConfigurePropertiesTest.java
@@ -24,6 +24,52 @@ public class ConfigurePropertiesTest {
   }
   
   @Test
+  public void testUnresolvableVariableThrowsRuntimeException() {
+    Properties delegateProps = new Properties();
+    delegateProps.put("test.key", "value_with_${unresolvable.var}");
+    Properties contextProps = new Properties(); // Ensure unresolvable.var is not here
+    
+    ConfigureProperties config = new ConfigureProperties(delegateProps, contextProps);
+    
+    try {
+      config.getProperty("test.key");
+      Assert.fail("Expected RuntimeException was not thrown.");
+    } catch (RuntimeException e) {
+      // Optionally, check if the cause is VariableNotFoundException
+      // This depends on the implementation of ConfigureProperties
+      // For now, just catching RuntimeException as specified.
+      Assert.assertTrue("RuntimeException should be thrown for unresolvable variable.", true);
+      // To be more specific if ConfigureProperties wraps VariableNotFoundException:
+      // Assert.assertTrue("Cause should be VariableNotFoundException", e.getCause() instanceof com.taobao.profile.utils.VariableNotFoundException);
+    }
+  }
+
+  @Test
+  public void testGetPropertyWithDefaultValue() {
+    // Scenario 1: Key not found, default value returned.
+    Properties delegateProps1 = new Properties();
+    Properties contextProps1 = new Properties();
+    ConfigureProperties config1 = new ConfigureProperties(delegateProps1, contextProps1);
+    Assert.assertEquals("defaultVal", config1.getProperty("nonexistent.key", "defaultVal"));
+
+    // Scenario 2: Key found, but unresolvable variable, RuntimeException thrown.
+    Properties delegateProps2 = new Properties();
+    delegateProps2.put("test.key.unresolvable", "value_with_${unresolvable.var.again}");
+    Properties contextProps2 = new Properties(); // Ensure unresolvable.var.again is not here
+    ConfigureProperties config2 = new ConfigureProperties(delegateProps2, contextProps2);
+    
+    try {
+      config2.getProperty("test.key.unresolvable", "defaultVal");
+      Assert.fail("Expected RuntimeException was not thrown for unresolvable variable with default value.");
+    } catch (RuntimeException e) {
+      // Optionally, check if the cause is VariableNotFoundException
+      Assert.assertTrue("RuntimeException should be thrown for unresolvable variable.", true);
+      // To be more specific if ConfigureProperties wraps VariableNotFoundException:
+      // Assert.assertTrue("Cause should be VariableNotFoundException", e.getCause() instanceof com.taobao.profile.utils.VariableNotFoundException);
+    }
+  }
+  
+  @Test
   public void testConfigure() throws IOException{
     Properties properties = new Properties();
     InputStream in = getClass().getClassLoader().getResourceAsStream("profile.properties");

--- a/src/test/java/com/taobao/profile/test/UtilitiesTest.java
+++ b/src/test/java/com/taobao/profile/test/UtilitiesTest.java
@@ -6,6 +6,8 @@ import org.junit.Test;
 import com.taobao.profile.utils.Utilities;
 import com.taobao.profile.utils.VariableNotFoundException;
 
+import java.util.Properties;
+
 public class UtilitiesTest{
 
   @Test
@@ -14,5 +16,81 @@ public class UtilitiesTest{
     String str1 = Utilities.repleseVariables(source, System.getProperties());
     String str2 = System.getProperty("user.home") + "/logs/" + System.getProperty("user.language") + "/tprofiler.log";  
     Assert.assertEquals(str1, str2);
+  }
+
+  @Test(expected = VariableNotFoundException.class)
+  public void testVariableNotFoundException() throws VariableNotFoundException {
+    String source = "${user.home}/${nonexistent.var}/file.log";
+    Utilities.repleseVariables(source, System.getProperties());
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testNullSource() throws VariableNotFoundException {
+    Utilities.repleseVariables(null, System.getProperties());
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testNullContext() throws VariableNotFoundException {
+    Utilities.repleseVariables("test", null);
+  }
+
+  @Test
+  public void testNoVariables() throws VariableNotFoundException {
+    String source = "This is a string without variables.";
+    String result = Utilities.repleseVariables(source, System.getProperties());
+    Assert.assertEquals(source, result);
+  }
+
+  @Test
+  public void testMalformedVariableExpressions() throws VariableNotFoundException {
+    // Use System.getProperties() as a context that is unlikely to contain test-specific keys.
+    Properties generalContext = System.getProperties();
+
+    String source1 = "${incomplete";
+    String result1 = Utilities.repleseVariables(source1, generalContext); 
+    Assert.assertEquals(source1, result1);
+
+    String source2 = "missing_brace}";
+    String result2 = Utilities.repleseVariables(source2, generalContext); 
+    Assert.assertEquals(source2, result2);
+    
+    // Test for "another ${var${inner}} case"
+    // Expecting VariableNotFoundException for key "inner}" based on previous observations.
+    String source3 = "another ${var${inner}} case";
+    try {
+      // Using a new empty context to ensure "inner}" is not found.
+      Utilities.repleseVariables(source3, new Properties()); 
+      Assert.fail("Expected VariableNotFoundException for source3 due to 'inner}' key not being found.");
+    } catch (VariableNotFoundException e) {
+      // Verify the specific key in the exception message.
+      Assert.assertEquals("variable inner} not found", e.getMessage());
+    }
+  }
+
+  @Test
+  public void testNestedVariableReplacementInnermostFirst() throws VariableNotFoundException {
+    String source = "another ${var${inner_key}} case";
+    Properties context = new Properties();
+    context.put("inner_key}", "resolved_inner"); 
+    context.put("varresolved_inner}", "final_value"); // This key won't be used if the outer var structure is lost
+    String result = Utilities.repleseVariables(source, context);
+    // Based on detailed trace, the '}' of the outer variable is lost after inner replacement.
+    Assert.assertEquals("another ${varresolved_inner case", result);
+  }
+  
+  @Test(expected = VariableNotFoundException.class)
+  public void testEmptyVariableNameWithEmptyContext() throws VariableNotFoundException {
+    String source = "${}";
+    Properties context = new Properties();
+    Utilities.repleseVariables(source, context);
+  }
+
+  @Test
+  public void testEmptyVariableNameWithMatchingContext() throws VariableNotFoundException {
+    String source = "${}";
+    Properties context = new Properties();
+    context.put("", "emptyKeyValue");
+    String result = Utilities.repleseVariables(source, context);
+    Assert.assertEquals("emptyKeyValue", result);
   }
 }


### PR DESCRIPTION
…roperties

This commit significantly improves the test coverage for the `com.taobao.profile.utils.Utilities` and
`com.taobao.profile.config.ConfigureProperties` classes.

For `Utilities.repleseVariables`:
- Added tests for `VariableNotFoundException` when a variable is not found.
- Added tests for `IllegalArgumentException` when source or context is null.
- Added tests for inputs containing no variables.
- Added tests for various malformed or nested variable expressions (e.g., `${incomplete}`, `missing_brace}`, `${var${inner_key}}`) to assert the actual current behavior of the substitution logic. This includes cases where keys are parsed as `key}` and where string reconstruction leads to malformed output for certain nested patterns.

For `ConfigureProperties`:
- Added tests for `getProperty(key)` to ensure a `RuntimeException` is thrown if a property's value contains an unresolvable variable.
- Added tests for `getProperty(key, defaultValue)` to ensure:
  - The default value is returned if the key is absent.
  - A `RuntimeException` is thrown if the key is present but its value contains an unresolvable variable (confirming the default value is not returned in this scenario).

Additionally, the Java version in `pom.xml` was updated from 1.6 to 1.8 to enable successful compilation and execution of the tests.